### PR TITLE
Add group chat context prompt and spectator mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5914,6 +5914,8 @@
                                         <div id="GroupFavDelOkBack" class="flex-container flexGap5 spaceEvenly flex1">
                                             <div id="rm_button_back_from_group" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-left-long"></div>
                                             <div id="rm_group_scenario" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-scroll" title="Set a group chat scenario" data-i18n="[title]Set a group chat scenario"></div>
+                                            <div id="rm_group_context" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-quote-left" title="Set a group context prompt" data-i18n="[title]Set a group context prompt"></div>
+                                            <div id="rm_group_chatter" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-comments" title="Let group members talk without you" data-i18n="[title]Let group members talk without you"></div>
                                             <div id="group_favorite_button" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites"></div>
                                             <input id="rm_group_fav" type="hidden" />
                                             <div id="group_open_media_overrides" class="heightFitContent margin0 menu_button menu_button_icon open_media_overrides" title="Click to allow/forbid the use of external media for this group." data-i18n="[title]Click to allow/forbid the use of external media for this group.">
@@ -5927,6 +5929,10 @@
                                                 <label class="checkbox_label whitespacenowrap">
                                                     <input id="rm_group_allow_self_responses" type="checkbox" />
                                                     <span data-i18n="Allow self responses">Allow self responses</span>
+                                                </label>
+                                                <label id="rm_group_spectator_mode_label" class="checkbox_label whitespacenowrap" title="Ignore the user and let the group carry the conversation." data-i18n="[title]Ignore the user and let the group carry the conversation.">
+                                                    <input id="rm_group_spectator_mode" type="checkbox" />
+                                                    <span data-i18n="Spectator mode">Spectator mode</span>
                                                 </label>
                                                 <label id="rm_group_automode_label" class="checkbox_label whitespacenowrap">
                                                     <input id="rm_group_automode" type="checkbox" />

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -808,7 +808,7 @@ function getGroupAvatar(group) {
     return groupAvatar;
 }
 
-export function getGroupChatNames(groupId) {
+function getGroupChatNames(groupId) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group) {
@@ -822,7 +822,7 @@ export function getGroupChatNames(groupId) {
     return names;
 }
 
-export function getGroupContextPrompt(groupId = selected_group) {
+function getGroupContextPrompt(groupId = selected_group) {
     const group = groups.find(x => x.id === groupId);
     if (!group) {
         return '';

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -81,6 +81,7 @@ import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map
 import { FILTER_TYPES, FilterHelper } from './filters.js';
 import { isExternalMediaAllowed } from './chats.js';
 import { POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
+import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 
@@ -101,6 +102,7 @@ export {
     resetSelectedGroup,
     select_group_chats,
     getGroupChatNames,
+    getGroupContextPrompt,
 };
 
 let is_group_generating = false; // Group generation flag
@@ -127,6 +129,9 @@ export const group_generation_mode = {
 };
 
 export const DEFAULT_AUTO_MODE_DELAY = 5;
+
+const NARRATOR_NAME_KEY = 'narrator_name';
+const NARRATOR_NAME_DEFAULT = 'System';
 
 export const groupCandidatesFilter = new FilterHelper(debounce(printGroupCandidates, debounce_timeout.quick));
 let autoModeWorker = null;
@@ -247,6 +252,13 @@ export async function getGroupChat(groupId, reload = false) {
     } else {
         freshChat = !metadata.tainted;
         if (group && Array.isArray(group.members) && freshChat) {
+            const contextMessage = createGroupContextMessage(group, metadata);
+            if (contextMessage) {
+                chat.push(contextMessage);
+                await eventSource.emit(event_types.MESSAGE_RECEIVED, (chat.length - 1), 'group_context');
+                addOneMessage(contextMessage);
+                await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, (chat.length - 1), 'group_context');
+            }
             for (let member of group.members) {
                 const character = characters.find(x => x.avatar === member || x.name === member);
                 if (!character) {
@@ -682,6 +694,10 @@ async function getGroups() {
             if (Array.isArray(group.chats) && group.chats.some(x => typeof x === 'number')) {
                 group.chats = group.chats.map(x => String(x));
             }
+            if (typeof group.context_prompt !== 'string') {
+                group.context_prompt = group.context_prompt ? String(group.context_prompt) : '';
+            }
+            group.spectator_mode = !!group.spectator_mode;
         }
     }
 }
@@ -792,7 +808,7 @@ function getGroupAvatar(group) {
     return groupAvatar;
 }
 
-function getGroupChatNames(groupId) {
+export function getGroupChatNames(groupId) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group) {
@@ -806,9 +822,61 @@ function getGroupChatNames(groupId) {
     return names;
 }
 
+export function getGroupContextPrompt(groupId = selected_group) {
+    const group = groups.find(x => x.id === groupId);
+    if (!group) {
+        return '';
+    }
+    return typeof group.context_prompt === 'string' ? group.context_prompt : '';
+}
+
+function getGroupMemberNamesForPrompt(group) {
+    if (!group || !Array.isArray(group.members)) {
+        return '';
+    }
+
+    return group.members
+        .map(member => characters.find(x => x.avatar === member || x.name === member)?.name)
+        .filter(Boolean)
+        .join(', ');
+}
+
+function createGroupContextMessage(group, metadata = {}) {
+    const rawPrompt = getGroupContextPrompt(group?.id);
+    const trimmedPrompt = rawPrompt?.trim();
+
+    if (!trimmedPrompt) {
+        return null;
+    }
+
+    const memberNames = getGroupMemberNamesForPrompt(group);
+    const substitutedPrompt = substituteParams(trimmedPrompt, undefined, undefined, undefined, memberNames);
+
+    if (!substitutedPrompt.trim()) {
+        return null;
+    }
+
+    const narratorName = metadata?.[NARRATOR_NAME_KEY] || chat_metadata?.[NARRATOR_NAME_KEY] || NARRATOR_NAME_DEFAULT;
+
+    return {
+        name: narratorName,
+        is_user: false,
+        is_system: true,
+        send_date: getMessageTimeStamp(),
+        force_avatar: system_avatar,
+        mes: substitutedPrompt,
+        extra: {
+            type: system_message_types.NARRATOR,
+            group_context: true,
+        },
+    };
+}
+
 async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
+    const { ignore_user_input: ignoreUserInputParam = false, preserve_draft: preserveDraft = false, ...generationParams } = params || {};
+
     function throwIfAborted() {
-        if (params.signal instanceof AbortSignal && params.signal.aborted) {
+        if (generationParams.signal instanceof AbortSignal && generationParams.signal.aborted) {
             throw new Error('AbortSignal was fired. Group generation stopped');
         }
     }
@@ -838,6 +906,9 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         return Promise.resolve();
     }
 
+    const $sendTextarea = $('#send_textarea');
+    let draftToRestore = null;
+
     try {
         await unshallowGroupMembers(selected_group);
 
@@ -846,7 +917,19 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         is_group_generating = true;
         setCharacterName('');
         setCharacterId(undefined);
-        const userInput = String($('#send_textarea').val());
+        let userInput = String($sendTextarea.val());
+
+        const spectatorMode = !!group.spectator_mode;
+        const ignoreUserInput = ignoreUserInputParam || spectatorMode;
+        const shouldRestoreDraft = ignoreUserInput && (spectatorMode || preserveDraft);
+
+        if (ignoreUserInput && userInput?.length) {
+            if (shouldRestoreDraft) {
+                draftToRestore = userInput;
+            }
+            $sendTextarea.val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+            userInput = '';
+        }
 
         // id of this specific batch for regeneration purposes
         group_generation_id = Date.now();
@@ -867,8 +950,8 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         const enabledMembers = group.members.filter(x => !group.disabled_members.includes(x));
         let activatedMembers = [];
 
-        if (params && typeof params.force_chid == 'number') {
-            activatedMembers = [params.force_chid];
+        if (typeof generationParams.force_chid === 'number') {
+            activatedMembers = [generationParams.force_chid];
         } else if (type === 'quiet') {
             activatedMembers = activateSwipe(group.members, { allowSystem: true }).slice(0, 1);
 
@@ -901,13 +984,17 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         }
 
         if (activatedMembers.length === 0) {
-            //toastr.warning('All group members are disabled. Enable at least one to get a reply.');
-
-            // Send user message as is
-            const bias = getBiasStrings(userInput, type);
-            await sendMessageAsUser(userInput, bias.messageBias);
-            await saveChatConditional();
-            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+            if (!ignoreUserInput && userInput?.length) {
+                const bias = getBiasStrings(userInput, type);
+                await sendMessageAsUser(userInput, bias.messageBias);
+                await saveChatConditional();
+                $sendTextarea.val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            if (draftToRestore !== null) {
+                $sendTextarea.val(draftToRestore)[0].dispatchEvent(new Event('input', { bubbles: true }));
+                draftToRestore = null;
+            }
+            return Promise.resolve();
         }
         groupChatQueueOrder = new Map();
 
@@ -930,12 +1017,12 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
 
             // Wait for generation to finish
             const generateType = ['swipe', 'impersonate', 'quiet', 'continue'].includes(type) ? type : 'normal';
-            textResult = await Generate(generateType, { automatic_trigger: by_auto_mode, ...(params || {}) });
+            textResult = await Generate(generateType, { automatic_trigger: by_auto_mode, ...generationParams });
             let messageChunk = textResult?.messageChunk;
 
             if (messageChunk) {
                 while (shouldAutoContinue(messageChunk, type === 'impersonate')) {
-                    textResult = await Generate('continue', { automatic_trigger: by_auto_mode, ...(params || {}) });
+                    textResult = await Generate('continue', { automatic_trigger: by_auto_mode, ...generationParams });
                     messageChunk = textResult?.messageChunk;
                 }
             }
@@ -945,6 +1032,10 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             }
         }
     } finally {
+        if (draftToRestore !== null) {
+            $sendTextarea.val(draftToRestore)[0].dispatchEvent(new Event('input', { bubbles: true }));
+            draftToRestore = null;
+        }
         is_group_generating = false;
         setSendButtonState(false);
         setCharacterId(undefined);
@@ -1538,6 +1629,20 @@ async function onGroupSelfResponsesClick() {
     }
 }
 
+async function onGroupSpectatorModeClick() {
+    if (!openGroupId) {
+        return;
+    }
+
+    const group = groups.find((x) => x.id == openGroupId);
+    if (!group) {
+        return;
+    }
+
+    group.spectator_mode = !!$(this).prop('checked');
+    await editGroup(openGroupId, false, false);
+}
+
 async function onHideMutedSpritesClick(value) {
     if (openGroupId) {
         let _thisGroup = groups.find((x) => x.id == openGroupId);
@@ -1546,6 +1651,45 @@ async function onHideMutedSpritesClick(value) {
         await editGroup(openGroupId, false, false);
         await eventSource.emit(event_types.GROUP_UPDATED);
     }
+}
+
+async function openGroupContextPrompt() {
+    if (!openGroupId) {
+        toastr.warning(t`Currently no group selected.`);
+        return;
+    }
+
+    const group = groups.find((x) => x.id == openGroupId);
+    if (!group) {
+        return;
+    }
+
+    const template = $(await renderTemplateAsync('groupContextPrompt'));
+    const textarea = template.find('.group_context_textarea');
+    textarea.val(group.context_prompt ?? '');
+    textarea.on('input', async function () {
+        group.context_prompt = String($(this).val());
+        await editGroup(openGroupId, false, false);
+    });
+    template.find('.group_context_reset').on('click', () => {
+        textarea.val('').trigger('input');
+    });
+
+    await callGenericPopup(template, POPUP_TYPE.TEXT, '', { large: true });
+}
+
+async function triggerGroupChatter() {
+    if (!selected_group) {
+        toastr.warning(t`Currently no group selected.`);
+        return;
+    }
+
+    if (is_group_generating) {
+        toastr.warning(t`Wait until the group finishes speaking before starting another turn.`);
+        return;
+    }
+
+    await generateGroupWrapper(false, 'observer', { ignore_user_input: true, preserve_draft: true });
 }
 
 function toggleHiddenControls(group, generationMode = null) {
@@ -1591,6 +1735,7 @@ function select_group_chats(groupId, skipAnimation) {
     const groupHasMembers = !!$('#rm_group_members').children().length;
     $('#rm_group_submit').prop('disabled', !groupHasMembers);
     $('#rm_group_allow_self_responses').prop('checked', group && group.allow_self_responses);
+    $('#rm_group_spectator_mode').prop('checked', group?.spectator_mode ?? false);
     $('#rm_group_hidemutedsprites').prop('checked', group && group.hideMutedSprites);
     $('#rm_group_automode_delay').val(group?.auto_mode_delay ?? DEFAULT_AUTO_MODE_DELAY);
 
@@ -1603,6 +1748,8 @@ function select_group_chats(groupId, skipAnimation) {
         $('#rm_group_submit').hide();
         $('#rm_group_delete').show();
         $('#rm_group_scenario').show();
+        $('#rm_group_context').show();
+        $('#rm_group_chatter').show();
         $('#group-metadata-controls .chat_lorebook_button').removeClass('disabled').prop('disabled', false);
         $('#group_open_media_overrides').show();
         const isMediaAllowed = isExternalMediaAllowed();
@@ -1615,6 +1762,8 @@ function select_group_chats(groupId, skipAnimation) {
         }
         $('#rm_group_delete').hide();
         $('#rm_group_scenario').hide();
+        $('#rm_group_context').hide();
+        $('#rm_group_chatter').hide();
         $('#group-metadata-controls .chat_lorebook_button').addClass('disabled').prop('disabled', true);
         $('#group_open_media_overrides').hide();
     }
@@ -1831,6 +1980,7 @@ function filterGroupMembers() {
 async function createGroup() {
     let name = $('#rm_group_chat_name').val();
     let allowSelfResponses = !!$('#rm_group_allow_self_responses').prop('checked');
+    let spectatorMode = !!$('#rm_group_spectator_mode').prop('checked');
     let activationStrategy = Number($('#rm_group_activation_strategy').find(':selected').val()) ?? group_activation_strategy.NATURAL;
     let generationMode = Number($('#rm_group_generation_mode').find(':selected').val()) ?? group_generation_mode.SWAP;
     let autoModeDelay = Number($('#rm_group_automode_delay').val()) ?? DEFAULT_AUTO_MODE_DELAY;
@@ -1863,6 +2013,8 @@ async function createGroup() {
             chat_id: chatName,
             chats: chats,
             auto_mode_delay: autoModeDelay,
+            context_prompt: '',
+            spectator_mode: spectatorMode,
         }),
     });
 
@@ -2177,6 +2329,8 @@ jQuery(() => {
     $('#rm_group_filter').on('input', filterGroupMembers);
     $('#rm_group_submit').on('click', createGroup);
     $('#rm_group_scenario').on('click', setScenarioOverride);
+    $('#rm_group_context').on('click', openGroupContextPrompt);
+    $('#rm_group_chatter').on('click', triggerGroupChatter);
     $('#rm_group_automode').on('input', function () {
         const value = $(this).prop('checked');
         is_group_automode_enabled = value;
@@ -2194,6 +2348,7 @@ jQuery(() => {
     $('#rm_group_delete').off().on('click', onDeleteGroupClick);
     $('#group_favorite_button').on('click', onFavoriteGroupClick);
     $('#rm_group_allow_self_responses').on('input', onGroupSelfResponsesClick);
+    $('#rm_group_spectator_mode').on('input', onGroupSpectatorModeClick);
     $('#rm_group_activation_strategy').on('change', onGroupActivationStrategyInput);
     $('#rm_group_generation_mode').on('change', onGroupGenerationModeInput);
     $('#rm_group_automode_delay').on('input', onGroupAutoModeDelayInput);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -30,7 +30,7 @@ import {
     system_message_types,
     this_chid,
 } from '../script.js';
-import { getGroupNames, selected_group } from './group-chats.js';
+import { getGroupNames, getGroupContextPrompt, selected_group } from './group-chats.js';
 
 import {
     chatCompletionDefaultPrompts,
@@ -1275,6 +1275,7 @@ async function populateChatCompletion(prompts, chatCompletion, { bias, quietProm
 async function preparePromptsForChatCompletion({ scenario, charPersonality, name2, worldInfoBefore, worldInfoAfter, charDescription, quietPrompt, bias, extensionPrompts, systemPromptOverride, jailbreakPromptOverride, type }) {
     const scenarioText = scenario && oai_settings.scenario_format ? substituteParams(oai_settings.scenario_format) : (scenario || '');
     const charPersonalityText = charPersonality && oai_settings.personality_format ? substituteParams(oai_settings.personality_format) : (charPersonality || '');
+    const groupContextPrompt = selected_group ? substituteParams(getGroupContextPrompt()).trim() : '';
     const groupNudge = substituteParams(oai_settings.group_nudge_prompt);
     const impersonationPrompt = oai_settings.impersonation_prompt ? substituteParams(oai_settings.impersonation_prompt) : '';
 
@@ -1286,6 +1287,7 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
         { role: 'system', content: charDescription, identifier: 'charDescription' },
         { role: 'system', content: charPersonalityText, identifier: 'charPersonality' },
         { role: 'system', content: scenarioText, identifier: 'scenario' },
+        ...(groupContextPrompt ? [{ role: 'system', content: groupContextPrompt, identifier: 'groupContext' }] : []),
         // Unordered prompts without marker
         { role: 'system', content: impersonationPrompt, identifier: 'impersonate' },
         { role: 'system', content: quietPrompt, identifier: 'quietPrompt' },

--- a/public/scripts/templates/groupContextPrompt.html
+++ b/public/scripts/templates/groupContextPrompt.html
@@ -1,0 +1,18 @@
+<div class="group_context range-block flexFlowColumn flex-container">
+    <div class="range-block-title title_restorable">
+        <h3><span data-i18n="Group context prompt" class="margin0">Group context prompt</span></h3>
+        <div title="Clear context prompt" data-i18n="[title]Clear context prompt"
+            class="menu_button fa-solid fa-trash-can group_context_reset"></div>
+    </div>
+    <div class="range-block-counter justifyLeft flex-container flexFlowColumn">
+        <span data-i18n="This text is sent to every group member at the start of the prompt.">This text is sent to every group member at the start of the prompt.</span>
+        <span data-i18n="Use it to describe relationships, rules, or tone for the group conversation.">Use it to describe relationships, rules, or tone for the group conversation.</span>
+    </div>
+    <div class="range-block-range wide100p">
+        <textarea class="wide100p group_context_textarea text_pole" rows="12" data-i18n="[placeholder]Type here..."
+            placeholder="Type here..."></textarea>
+    </div>
+    <div class="range-block-counter justifyLeft flex-container flexFlowColumn">
+        <small data-i18n="Macros such as {{user}} and {{group}} are supported.">Macros such as {{user}} and {{group}} are supported.</small>
+    </div>
+</div>

--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -76,6 +76,8 @@ router.post('/create', (request, response) => {
         auto_mode_delay: request.body.auto_mode_delay ?? 5,
         generation_mode_join_prefix: request.body.generation_mode_join_prefix ?? '',
         generation_mode_join_suffix: request.body.generation_mode_join_suffix ?? '',
+        context_prompt: request.body.context_prompt ?? '',
+        spectator_mode: !!request.body.spectator_mode,
     };
     const pathToFile = path.join(request.user.directories.groups, sanitize(`${id}.json`));
     const fileData = JSON.stringify(groupMetadata, null, 4);


### PR DESCRIPTION
## Summary
- add UI controls for configuring group context prompts, spectator mode, and quick chatter triggers in the group editor
- persist new group context instructions and spectator settings, inject narrator context messages for fresh chats, and ensure generation ignores user input when desired
- include the group context prompt in OpenAI system prompts and expose the new metadata on the backend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5fe9246d8832b826a6f79ac66eb5c