### PR TITLE
Add SuperTavern settings drawer and hide command deck overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4850,398 +4850,132 @@
             <div id="supertavern-settings" class="drawer-content closedDrawer">
                 <div id="supertavern-settings-panel" class="supertavern-settings-panel flex-container flexFlowColumn wide100p flex1">
                     <div class="supertavern-settings-group">
-                        <h3>Real-Time Multi-User Chat Rooms</h3>
-                        <ul>
-                            <li>Allow multiple human users to join the same conversation simultaneously</li>
-                            <li>Real-time synchronization with conflict resolution for simultaneous messages</li>
-                            <li>User roles and permissions (moderator, participant, observer)</li>
-                            <li>Private side conversations within group chats</li>
-                            <li>Cross-talk functionality (user-to-user communication using "/" prefix)</li>
-                        </ul>
+                        <h3>Real-Time Collaboration</h3>
+                        <p class="supertavern-description">Coordinate live sessions with multi-user chat, moderation roles, and private threads.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="multiUser.enabled">
+                            <span>Enable real-time multi-user chat rooms</span>
+                        </label>
+                        <div class="supertavern-subgroup" data-supertavern-requires="multiUser.enabled">
+                            <label class="supertavern-toggle">
+                                <input type="checkbox" data-supertavern-setting="multiUser.conflictResolution">
+                                <span>Real-time synchronization with conflict resolution</span>
+                            </label>
+                            <label class="supertavern-toggle">
+                                <input type="checkbox" data-supertavern-setting="multiUser.privateSideChats">
+                                <span>Allow private side conversations within group chats</span>
+                            </label>
+                            <label class="supertavern-toggle">
+                                <input type="checkbox" data-supertavern-setting="multiUser.crossTalk">
+                                <span>Cross-talk functionality using <code>/name</code> prefix</span>
+                            </label>
+                            <div class="supertavern-role-select">
+                                <label for="supertavern-role">Your role</label>
+                                <select id="supertavern-role" data-supertavern-setting="multiUser.role">
+                                    <option value="participant">Participant</option>
+                                    <option value="moderator">Moderator</option>
+                                    <option value="observer">Observer</option>
+                                </select>
+                            </div>
+                            <div class="supertavern-status">
+                                <span>Status:</span>
+                                <span id="supertavern-multiuser-status">Offline</span>
+                            </div>
+                        </div>
                     </div>
                     <div class="supertavern-settings-group">
                         <h3>Shared Memory Systems</h3>
-                        <ul>
-                            <li>Persistent shared knowledge base across multiple users</li>
-                            <li>Project-specific shared memory that updates in real-time</li>
-                            <li>Privacy controls for what gets shared vs. kept private</li>
-                            <li>Collaborative world-building with version control</li>
-                        </ul>
+                        <p class="supertavern-description">Capture project knowledge as the conversation evolves and keep teams aligned.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="sharedMemory.enabled">
+                            <span>Persistent shared knowledge base across users</span>
+                        </label>
+                        <div class="supertavern-subgroup" data-supertavern-requires="sharedMemory.enabled">
+                            <label class="supertavern-toggle">
+                                <input type="checkbox" data-supertavern-setting="sharedMemory.projectScoped">
+                                <span>Use project-specific shared memory</span>
+                            </label>
+                            <label class="supertavern-toggle">
+                                <input type="checkbox" data-supertavern-setting="sharedMemory.privacyControls">
+                                <span>Respect privacy controls before sharing</span>
+                            </label>
+                            <div class="supertavern-memory-toolbar">
+                                <button type="button" id="supertavern-shared-memory-export" class="menu_button">Export snapshot</button>
+                                <button type="button" id="supertavern-shared-memory-clear" class="menu_button">Clear project memory</button>
+                            </div>
+                            <div class="supertavern-shared-memory">
+                                <ul id="supertavern-shared-memory-list" aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
                     <div class="supertavern-settings-group">
-                        <h3>Team Workspaces</h3>
-                        <ul>
-                            <li>Role-based access control for different team functions</li>
-                            <li>Shared character libraries and prompt templates</li>
-                            <li>Team analytics and usage tracking</li>
-                            <li>Centralized billing and subscription management</li>
-                        </ul>
+                        <h3>Team Workspaces &amp; Analytics</h3>
+                        <p class="supertavern-description">Track participation and coordinate shared assets across collaborators.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="team.analyticsEnabled">
+                            <span>Enable team analytics and usage tracking</span>
+                        </label>
+                        <div class="supertavern-subgroup" data-supertavern-requires="team.analyticsEnabled">
+                            <p class="supertavern-hint">Message volume is tallied in real-time for every participant.</p>
+                            <ul id="supertavern-team-analytics" class="supertavern-team-list" aria-live="polite"></ul>
+                        </div>
                     </div>
                     <div class="supertavern-settings-group">
-                        <h3>Gamification &amp; Achievement Systems</h3>
-                        <ul>
-                            <li>
-                                <strong>Experience Point System</strong>
-                                <ul>
-                                    <li>Earn XP for various activities (daily chat, trying new features, creative writing)</li>
-                                    <li>Level progression unlocks new customization options</li>
-                                    <li>Achievement badges for milestones (1000 messages, first group chat, etc.)</li>
-                                    <li>Seasonal challenges and events</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Interactive Storytelling Modes</strong>
-                                <ul>
-                                    <li>Choose-your-own-adventure style conversations</li>
-                                    <li>Branching narrative trees with save points</li>
-                                    <li>Story collaboration between multiple users</li>
-                                    <li>Interactive fiction creation tools</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Mini-Games Integration</strong>
-                                <ul>
-                                    <li>Built-in games like chess, dice rolling, trivia</li>
-                                    <li>AI-powered puzzle generation</li>
-                                    <li>Collaborative problem-solving challenges</li>
-                                    <li>RPG-style character stat systems</li>
-                                </ul>
-                            </li>
-                        </ul>
+                        <h3>Gamification &amp; Achievements</h3>
+                        <p class="supertavern-description">Reward healthy collaboration with XP, levels, and collectible badges.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="gamification.enabled">
+                            <span>Enable experience tracking and badges</span>
+                        </label>
+                        <div class="supertavern-subgroup" data-supertavern-requires="gamification.enabled">
+                            <div class="supertavern-xp-meter">
+                                <span id="supertavern-xp-level">Level 1</span>
+                                <progress id="supertavern-xp-progress" max="100" value="0" aria-label="Experience progress"></progress>
+                                <span id="supertavern-xp-value" class="supertavern-xp-value">0 XP</span>
+                            </div>
+                            <div>
+                                <h4 class="supertavern-subheading">Achievements</h4>
+                                <ul id="supertavern-achievements" class="supertavern-achievement-list" aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
                     <div class="supertavern-settings-group">
-                        <h3>Enhanced Accessibility Features</h3>
-                        <ul>
-                            <li>
-                                <strong>Advanced Screen Reader Support</strong>
-                                <ul>
-                                    <li>Optimized ARIA labels and live regions</li>
-                                    <li>Customizable announcement preferences</li>
-                                    <li>Keyboard navigation shortcuts</li>
-                                    <li>High contrast and dyslexia-friendly themes</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Multi-Modal Accessibility</strong>
-                                <ul>
-                                    <li>Voice-first interaction modes</li>
-                                    <li>Gesture-based navigation for mobile</li>
-                                    <li>Customizable font sizes and spacing</li>
-                                    <li>Color-blind friendly interface options</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Neurodivergent-Friendly Features</strong>
-                                <ul>
-                                    <li>Reduced motion options</li>
-                                    <li>Focus management tools</li>
-                                    <li>Cognitive load reduction settings</li>
-                                    <li>Sensory-friendly color schemes</li>
-                                </ul>
-                            </li>
-                        </ul>
+                        <h3>Enhanced Accessibility</h3>
+                        <p class="supertavern-description">Adapt the interface for screen readers, sensory comfort, and focus management.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="accessibility.highContrast">
+                            <span>Enable high-contrast theme adjustments</span>
+                        </label>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="accessibility.dyslexiaFriendly">
+                            <span>Dyslexia-friendly font and spacing</span>
+                        </label>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="accessibility.reducedMotion">
+                            <span>Reduced motion and animation</span>
+                        </label>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="accessibility.focusManagement">
+                            <span>Enable focus management tools</span>
+                        </label>
                     </div>
                     <div class="supertavern-settings-group">
-                        <h3>Advanced AI Integration</h3>
-                        <ul>
-                            <li>
-                                <strong>Multi-Model Ensemble Conversations</strong>
-                                <ul>
-                                    <li>Run multiple AI models simultaneously for consensus responses</li>
-                                    <li>Model voting systems for better accuracy</li>
-                                    <li>Specialized model routing based on query type</li>
-                                    <li>Cross-model knowledge verification</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Dynamic Model Switching</strong>
-                                <ul>
-                                    <li>Automatic model selection based on conversation context</li>
-                                    <li>Performance monitoring and adaptive switching</li>
-                                    <li>Cost optimization algorithms</li>
-                                    <li>Fallback model chains</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>AI Agent Orchestration</strong>
-                                <ul>
-                                    <li>Multiple specialized AI agents working together</li>
-                                    <li>Agent-to-agent communication within conversations</li>
-                                    <li>Task delegation between different AI capabilities</li>
-                                    <li>Workflow automation with AI agents</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Creative &amp; Content Generation Tools</h3>
-                        <ul>
-                            <li>
-                                <strong>Collaborative Writing Suite</strong>
-                                <ul>
-                                    <li>Real-time collaborative document editing within chat</li>
-                                    <li>Version history and branching for creative projects</li>
-                                    <li>AI-assisted story planning and character development</li>
-                                    <li>Export to various formats (PDF, EPUB, etc.)</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Advanced Image Generation Integration</strong>
-                                <ul>
-                                    <li>Context-aware image generation from conversation</li>
-                                    <li>Character consistency across generated images</li>
-                                    <li>Style transfer and image editing tools</li>
-                                    <li>3D avatar generation and customization</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Multimedia Content Creation</strong>
-                                <ul>
-                                    <li>AI-powered voice cloning for characters</li>
-                                    <li>Background music generation based on mood</li>
-                                    <li>Sound effect libraries for immersive experiences</li>
-                                    <li>Video generation for character interactions</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Advanced Memory &amp; Context Management</h3>
-                        <ul>
-                            <li>
-                                <strong>Semantic Memory Clustering</strong>
-                                <ul>
-                                    <li>Intelligent grouping of related memories</li>
-                                    <li>Context-aware memory retrieval</li>
-                                    <li>Memory importance scoring and pruning</li>
-                                    <li>Cross-character memory sharing</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Dynamic Context Windows</strong>
-                                <ul>
-                                    <li>Adaptive context size based on conversation importance</li>
-                                    <li>Smart token allocation for optimal performance</li>
-                                    <li>Context compression algorithms</li>
-                                    <li>Multi-layered memory hierarchies</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Persistent World States</strong>
-                                <ul>
-                                    <li>Maintain consistent world information across sessions</li>
-                                    <li>Time progression and event tracking</li>
-                                    <li>Character relationship dynamics</li>
-                                    <li>Environmental state persistence</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Enhanced Customization &amp; Theming</h3>
-                        <ul>
-                            <li>
-                                <strong>Advanced Theme Engine</strong>
-                                <ul>
-                                    <li>Node-based theme editor</li>
-                                    <li>Dynamic themes that change based on conversation mood</li>
-                                    <li>Community theme marketplace</li>
-                                    <li>Import/export theme packages</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Procedural UI Generation</strong>
-                                <ul>
-                                    <li>AI-generated interface layouts</li>
-                                    <li>Adaptive UI based on usage patterns</li>
-                                    <li>Personalized dashboard creation</li>
-                                    <li>Context-sensitive control panels</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Advanced Character Customization</strong>
-                                <ul>
-                                    <li>3D character model integration</li>
-                                    <li>Facial expression animation</li>
-                                    <li>Voice synthesis training</li>
-                                    <li>Personality trait sliders with behavioral impact</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Analytics &amp; Insights</h3>
-                        <ul>
-                            <li>
-                                <strong>Conversation Analytics Dashboard</strong>
-                                <ul>
-                                    <li>Word count and sentiment tracking</li>
-                                    <li>Character development progress</li>
-                                    <li>Relationship mapping between characters</li>
-                                    <li>Usage pattern analysis</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>AI Performance Metrics</strong>
-                                <ul>
-                                    <li>Response quality tracking</li>
-                                    <li>Model comparison analytics</li>
-                                    <li>Cost optimization insights</li>
-                                    <li>Performance benchmarking</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Personal Growth Tracking</strong>
-                                <ul>
-                                    <li>Writing skill progression</li>
-                                    <li>Creative milestone achievements</li>
-                                    <li>Learning progress in different topics</li>
-                                    <li>Social interaction improvements</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Integration &amp; Automation</h3>
-                        <ul>
-                            <li>
-                                <strong>External Service Integration</strong>
-                                <ul>
-                                    <li>Calendar and scheduling connectivity</li>
-                                    <li>Note-taking app synchronization</li>
-                                    <li>Social media cross-posting</li>
-                                    <li>Email integration for conversation summaries</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Workflow Automation</strong>
-                                <ul>
-                                    <li>Custom STscript marketplace</li>
-                                    <li>Visual workflow builder</li>
-                                    <li>Trigger-based automation</li>
-                                    <li>Integration with productivity tools</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>API Ecosystem</strong>
-                                <ul>
-                                    <li>RESTful API for third-party integrations</li>
-                                    <li>Webhook support for external events</li>
-                                    <li>Plugin architecture for community extensions</li>
-                                    <li>GraphQL interface for advanced queries</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Advanced Search &amp; Organization</h3>
-                        <ul>
-                            <li>
-                                <strong>Semantic Search Across All Conversations</strong>
-                                <ul>
-                                    <li>Natural language query for finding specific conversations</li>
-                                    <li>Cross-character search capabilities</li>
-                                    <li>Context-aware result ranking</li>
-                                    <li>Advanced filtering and sorting options</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Smart Organization Systems</strong>
-                                <ul>
-                                    <li>AI-powered conversation categorization</li>
-                                    <li>Automatic tagging based on content</li>
-                                    <li>Relationship mapping between characters and topics</li>
-                                    <li>Timeline view of conversation history</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Knowledge Graph Integration</strong>
-                                <ul>
-                                    <li>Visual representation of character relationships</li>
-                                    <li>Topic connection mapping</li>
-                                    <li>Interactive exploration of conversation networks</li>
-                                    <li>Export to graph analysis tools</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Privacy &amp; Security Enhancements</h3>
-                        <ul>
-                            <li>
-                                <strong>Advanced Encryption</strong>
-                                <ul>
-                                    <li>End-to-end encryption for sensitive conversations</li>
-                                    <li>Local-only processing options</li>
-                                    <li>Selective cloud sync with encryption</li>
-                                    <li>Zero-knowledge architecture options</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Privacy Controls</strong>
-                                <ul>
-                                    <li>Granular data sharing permissions</li>
-                                    <li>Automatic PII detection and masking</li>
-                                    <li>Conversation anonymization tools</li>
-                                    <li>Data retention policy customization</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Mobile &amp; Cross-Platform</h3>
-                        <ul>
-                            <li>
-                                <strong>Progressive Web App Enhancement</strong>
-                                <ul>
-                                    <li>Offline conversation capabilities</li>
-                                    <li>Push notification system</li>
-                                    <li>Mobile-optimized gesture controls</li>
-                                    <li>Responsive design improvements</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Cross-Device Synchronization</strong>
-                                <ul>
-                                    <li>Real-time sync across multiple devices</li>
-                                    <li>Device-specific customization preservation</li>
-                                    <li>Bandwidth optimization for mobile</li>
-                                    <li>Conflict resolution for simultaneous edits</li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="supertavern-settings-group">
-                        <h3>Community &amp; Social Features</h3>
-                        <ul>
-                            <li>
-                                <strong>Character Sharing Marketplace</strong>
-                                <ul>
-                                    <li>Community-driven character library</li>
-                                    <li>Rating and review system for characters</li>
-                                    <li>Version control for shared characters</li>
-                                    <li>Monetization options for character creators</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Collaborative World Building</strong>
-                                <ul>
-                                    <li>Shared universe creation tools</li>
-                                    <li>Community-driven lore development</li>
-                                    <li>Voting systems for canonical events</li>
-                                    <li>Collaborative timeline management</li>
-                                </ul>
-                            </li>
-                            <li>
-                                <strong>Social Discovery</strong>
-                                <ul>
-                                    <li>Find users with similar interests</li>
-                                    <li>Public conversation showcases</li>
-                                    <li>Community challenges and events</li>
-                                    <li>Mentorship matching system</li>
-                                </ul>
-                            </li>
-                        </ul>
+                        <h3>Advanced Customization</h3>
+                        <p class="supertavern-description">Drive dynamic themes and procedural layouts that respond to collaboration.</p>
+                        <label class="supertavern-toggle">
+                            <input type="checkbox" data-supertavern-setting="customization.dynamicThemes">
+                            <span>Dynamic theme reactions to conversation mood</span>
+                        </label>
+                        <div class="supertavern-roadmap">
+                            <p class="supertavern-hint">Need integrations, automation, or content tooling? Track ongoing roadmap items below.</p>
+                            <ul class="supertavern-roadmap-list">
+                                <li>Integration &amp; automation pipeline (webhooks, STscript marketplace)</li>
+                                <li>Advanced AI ensemble routing and agent orchestration</li>
+                                <li>Creative toolchain upgrades for multimedia collaboration</li>
+                                <li>Semantic search, knowledge graphs, and privacy enhancements</li>
+                                <li>Community marketplace, seasonal challenges, and mobile sync</li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -4605,60 +4605,14 @@
                 </div>
             </div>
         </div>
-        <div id="supertavern-settings-button" class="drawer">
+        <div id="ui-settings-button" class="drawer">
             <div class="drawer-toggle">
-                <div class="drawer-icon fa-solid fa-wand-magic-sparkles fa-fw closedIcon" title="SuperTavern Settings"></div>
-            </div>
-            <div id="supertavern-settings" class="drawer-content closedDrawer">
-                <div id="supertavern-settings-panel" class="flex-container flexFlowColumn wide100p flex1"></div>
-            </div>
-        </div>
-        <div id="user-settings-button" class="drawer">
-            <div class="drawer-toggle">
-                <div class="drawer-icon fa-solid fa-user-cog fa-fw closedIcon" title="User Settings" data-i18n="[title]User Settings"></div>
-            </div>
-            <div id="user-settings-block" class="drawer-content closedDrawer">
-                <div class="flex-container flexFlowColumn">
-                    <div name="userSettingsRowOne" class="flex-container flexFlowRow alignitemscenter spaceBetween">
-                        <div class="flex-container">
-                            <div class="flex-container flexnowrap alignItemsBaseline">
-                                <h3 class="margin0">
-                                    <span data-i18n="User Settings">User Settings</span>
-
-                                    <a href="https://docs.sillytavern.app/usage/user-settings/" class="notes-link" target="_blank">
-                                        <span class="fa-solid fa-circle-question note-link-span"></span>
-                                    </a>
-                                </h3>
-                            </div>
-                        </div>
-                        <div id="UI-language-block" class="flex-container alignItemsBaseline">
-                            <span data-i18n="UI Language">Language:</span>
-                            <select id="ui_language_select" class="flex1 margin0 text_pole">
-                                <option value="" data-i18n="Default">Default</option>
-                                <option value="en">English</option>
-                            </select>
-                        </div>
-                        <small id="version_display"></small>
-                    </div>
-                    <div name="UserSettingsRowTwo" class="flex-container flexFlowRow">
-                        <div id="account_controls" class="flex-container">
-                            <div id="account_button" class="margin0 menu_button_icon menu_button">
-                                <i class="fa-fw fa-solid fa-user-shield"></i>
-                                <span data-i18n="Account">Account</span>
-                            </div>
-                            <div id="admin_button" class="margin0 menu_button_icon menu_button">
-                                <i class="fa-fw fa-solid fa-user-tie"></i>
-                                <span data-i18n="Admin Panel">Admin Panel</span>
-                            </div>
-                            <div id="logout_button" class="margin0 menu_button_icon menu_button">
-                                <i class="fa-fw fa-solid fa-right-from-bracket"></i>
-                                <span data-i18n="Logout">Logout</span>
-                            </div>
-                        </div>
-                        <textarea id="settingsSearch" class="textarea_compact flex1" rows="1" placeholder="Search Settings" data-i18n="[placeholder]Search Settings"></textarea>
-                    </div>
+                <div class="drawer-icon fa-solid fa-palette fa-fw closedIcon" title="UI Settings" aria-label="UI Settings" data-i18n="[title]UI Settings">
+                    <span class="drawer-label" data-i18n="UI Settings">UI Settings</span>
                 </div>
-                <div id="user-settings-block-content" class="flex-container spaceEvenly">
+            </div>
+            <div id="ui-settings" class="drawer-content closedDrawer">
+                <div id="ui-settings-panel" class="flex-container flexFlowColumn wide100p flex1">
                     <div name="UserSettingsFirstColumn" id="UI-Theme-Block" class="flex-container flexFlowColumn wide100p flex1">
                         <div id="UI-presets-block" class="flex-container flexFlowColumn">
                             <h4 class="title_restorable">
@@ -4774,41 +4728,29 @@
 
                                 <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
                                     <small>
-                                        <span>
-                                            <span data-i18n="Chat Width">Chat Width</span>
-                                            <i class="fa-solid fa-desktop"></i>
-                                        </span>
-                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Width of the main chat window in % of screen width" title="Width of the main chat window in % of screen width"></div>
+                                        <span data-i18n="Chat Font Size">Chat Font Size</span>
+                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Changes the font size of chat messages." title="Changes the font size of chat messages."></div>
                                     </small>
-                                    <input class="neo-range-slider" type="range" id="chat_width_slider" name="chat_width_slider" min="25" max="100" step="1">
-                                    <input class="neo-range-input" type="number" min="25" max="100" step="1" data-for="chat_width_slider" id="chat_width_slider_counter">
+                                    <input class="neo-range-slider" type="range" id="font_size" name="font_size" min="70" max="170" step="5">
+                                    <input class="neo-range-input" type="number" min="70" max="170" step="5" data-for="font_size" id="font_size_counter">
                                 </div>
 
                                 <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
                                     <small>
-                                        <span data-i18n="Font Scale">Font Scale</span>
-                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Font size" title="Font size"></div>
+                                        <span data-i18n="Chat Width">Chat Width</span>
+                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Changes the width of the chat area." title="Changes the width of the chat area."></div>
                                     </small>
-                                    <input class="neo-range-slider" type="range" id="font_scale" name="font_scale" min="0.5" max="1.5" step="0.01">
-                                    <input class="neo-range-input" type="number" min="0.5" max="1.5" step="0.01" data-for="font_scale" id="font_scale_counter">
+                                    <input class="neo-range-slider" type="range" id="chat_display_mode" name="chat_display_mode" min="0" max="2" step="1">
+                                    <input class="neo-range-input" type="number" min="0" max="2" step="1" data-for="chat_display_mode" id="chat_display_mode_counter">
                                 </div>
 
                                 <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
                                     <small>
-                                        <span data-i18n="Blur Strength">Blur Strength</span>
-                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Blur strength on UI panels." title="Blur strength on UI panels."></div>
+                                        <span data-i18n="Chat Blur">Chat Blur</span>
+                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Changes the blur intensity behind chat windows." title="Changes the blur intensity behind chat windows."></div>
                                     </small>
-                                    <input class="neo-range-slider" type="range" id="blur_strength" name="blur_strength" min="0" max="30" step="1">
-                                    <input class="neo-range-input" type="number" min="0" max="30" step="1" data-for="blur_strength" id="blur_strength_counter">
-                                </div>
-
-                                <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
-                                    <small>
-                                        <span data-i18n="Text Shadow Width">Shadow Width</span>
-                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Strength of the text shadows" title="Strength of the text shadows"></div>
-                                    </small>
-                                    <input class="neo-range-slider" type="range" id="shadow_width" name="shadow_width" min="0" max="5" step="1">
-                                    <input class="neo-range-input" type="number" min="0" max="5" step="1" data-for="shadow_width" id="shadow_width_counter">
+                                    <input class="neo-range-slider" type="range" id="blur_intensity" name="blur_intensity" min="0" max="12" step="1">
+                                    <input class="neo-range-input" type="number" min="0" max="12" step="1" data-for="blur_intensity" id="blur_intensity_counter">
                                 </div>
                             </div>
                             <hr>
@@ -4896,6 +4838,460 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+        <div id="supertavern-settings-button" class="drawer">
+            <div class="drawer-toggle">
+                <div class="drawer-icon fa-solid fa-wand-magic-sparkles fa-fw closedIcon" title="SuperTavern Settings" aria-label="SuperTavern Settings" data-i18n="[title]SuperTavern Settings">
+                    <span class="drawer-label" data-i18n="SuperTavern Settings">SuperTavern Settings</span>
+                </div>
+            </div>
+            <div id="supertavern-settings" class="drawer-content closedDrawer">
+                <div id="supertavern-settings-panel" class="supertavern-settings-panel flex-container flexFlowColumn wide100p flex1">
+                    <div class="supertavern-settings-group">
+                        <h3>Real-Time Multi-User Chat Rooms</h3>
+                        <ul>
+                            <li>Allow multiple human users to join the same conversation simultaneously</li>
+                            <li>Real-time synchronization with conflict resolution for simultaneous messages</li>
+                            <li>User roles and permissions (moderator, participant, observer)</li>
+                            <li>Private side conversations within group chats</li>
+                            <li>Cross-talk functionality (user-to-user communication using "/" prefix)</li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Shared Memory Systems</h3>
+                        <ul>
+                            <li>Persistent shared knowledge base across multiple users</li>
+                            <li>Project-specific shared memory that updates in real-time</li>
+                            <li>Privacy controls for what gets shared vs. kept private</li>
+                            <li>Collaborative world-building with version control</li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Team Workspaces</h3>
+                        <ul>
+                            <li>Role-based access control for different team functions</li>
+                            <li>Shared character libraries and prompt templates</li>
+                            <li>Team analytics and usage tracking</li>
+                            <li>Centralized billing and subscription management</li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Gamification &amp; Achievement Systems</h3>
+                        <ul>
+                            <li>
+                                <strong>Experience Point System</strong>
+                                <ul>
+                                    <li>Earn XP for various activities (daily chat, trying new features, creative writing)</li>
+                                    <li>Level progression unlocks new customization options</li>
+                                    <li>Achievement badges for milestones (1000 messages, first group chat, etc.)</li>
+                                    <li>Seasonal challenges and events</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Interactive Storytelling Modes</strong>
+                                <ul>
+                                    <li>Choose-your-own-adventure style conversations</li>
+                                    <li>Branching narrative trees with save points</li>
+                                    <li>Story collaboration between multiple users</li>
+                                    <li>Interactive fiction creation tools</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Mini-Games Integration</strong>
+                                <ul>
+                                    <li>Built-in games like chess, dice rolling, trivia</li>
+                                    <li>AI-powered puzzle generation</li>
+                                    <li>Collaborative problem-solving challenges</li>
+                                    <li>RPG-style character stat systems</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Enhanced Accessibility Features</h3>
+                        <ul>
+                            <li>
+                                <strong>Advanced Screen Reader Support</strong>
+                                <ul>
+                                    <li>Optimized ARIA labels and live regions</li>
+                                    <li>Customizable announcement preferences</li>
+                                    <li>Keyboard navigation shortcuts</li>
+                                    <li>High contrast and dyslexia-friendly themes</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Multi-Modal Accessibility</strong>
+                                <ul>
+                                    <li>Voice-first interaction modes</li>
+                                    <li>Gesture-based navigation for mobile</li>
+                                    <li>Customizable font sizes and spacing</li>
+                                    <li>Color-blind friendly interface options</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Neurodivergent-Friendly Features</strong>
+                                <ul>
+                                    <li>Reduced motion options</li>
+                                    <li>Focus management tools</li>
+                                    <li>Cognitive load reduction settings</li>
+                                    <li>Sensory-friendly color schemes</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Advanced AI Integration</h3>
+                        <ul>
+                            <li>
+                                <strong>Multi-Model Ensemble Conversations</strong>
+                                <ul>
+                                    <li>Run multiple AI models simultaneously for consensus responses</li>
+                                    <li>Model voting systems for better accuracy</li>
+                                    <li>Specialized model routing based on query type</li>
+                                    <li>Cross-model knowledge verification</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Dynamic Model Switching</strong>
+                                <ul>
+                                    <li>Automatic model selection based on conversation context</li>
+                                    <li>Performance monitoring and adaptive switching</li>
+                                    <li>Cost optimization algorithms</li>
+                                    <li>Fallback model chains</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>AI Agent Orchestration</strong>
+                                <ul>
+                                    <li>Multiple specialized AI agents working together</li>
+                                    <li>Agent-to-agent communication within conversations</li>
+                                    <li>Task delegation between different AI capabilities</li>
+                                    <li>Workflow automation with AI agents</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Creative &amp; Content Generation Tools</h3>
+                        <ul>
+                            <li>
+                                <strong>Collaborative Writing Suite</strong>
+                                <ul>
+                                    <li>Real-time collaborative document editing within chat</li>
+                                    <li>Version history and branching for creative projects</li>
+                                    <li>AI-assisted story planning and character development</li>
+                                    <li>Export to various formats (PDF, EPUB, etc.)</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Advanced Image Generation Integration</strong>
+                                <ul>
+                                    <li>Context-aware image generation from conversation</li>
+                                    <li>Character consistency across generated images</li>
+                                    <li>Style transfer and image editing tools</li>
+                                    <li>3D avatar generation and customization</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Multimedia Content Creation</strong>
+                                <ul>
+                                    <li>AI-powered voice cloning for characters</li>
+                                    <li>Background music generation based on mood</li>
+                                    <li>Sound effect libraries for immersive experiences</li>
+                                    <li>Video generation for character interactions</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Advanced Memory &amp; Context Management</h3>
+                        <ul>
+                            <li>
+                                <strong>Semantic Memory Clustering</strong>
+                                <ul>
+                                    <li>Intelligent grouping of related memories</li>
+                                    <li>Context-aware memory retrieval</li>
+                                    <li>Memory importance scoring and pruning</li>
+                                    <li>Cross-character memory sharing</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Dynamic Context Windows</strong>
+                                <ul>
+                                    <li>Adaptive context size based on conversation importance</li>
+                                    <li>Smart token allocation for optimal performance</li>
+                                    <li>Context compression algorithms</li>
+                                    <li>Multi-layered memory hierarchies</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Persistent World States</strong>
+                                <ul>
+                                    <li>Maintain consistent world information across sessions</li>
+                                    <li>Time progression and event tracking</li>
+                                    <li>Character relationship dynamics</li>
+                                    <li>Environmental state persistence</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Enhanced Customization &amp; Theming</h3>
+                        <ul>
+                            <li>
+                                <strong>Advanced Theme Engine</strong>
+                                <ul>
+                                    <li>Node-based theme editor</li>
+                                    <li>Dynamic themes that change based on conversation mood</li>
+                                    <li>Community theme marketplace</li>
+                                    <li>Import/export theme packages</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Procedural UI Generation</strong>
+                                <ul>
+                                    <li>AI-generated interface layouts</li>
+                                    <li>Adaptive UI based on usage patterns</li>
+                                    <li>Personalized dashboard creation</li>
+                                    <li>Context-sensitive control panels</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Advanced Character Customization</strong>
+                                <ul>
+                                    <li>3D character model integration</li>
+                                    <li>Facial expression animation</li>
+                                    <li>Voice synthesis training</li>
+                                    <li>Personality trait sliders with behavioral impact</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Analytics &amp; Insights</h3>
+                        <ul>
+                            <li>
+                                <strong>Conversation Analytics Dashboard</strong>
+                                <ul>
+                                    <li>Word count and sentiment tracking</li>
+                                    <li>Character development progress</li>
+                                    <li>Relationship mapping between characters</li>
+                                    <li>Usage pattern analysis</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>AI Performance Metrics</strong>
+                                <ul>
+                                    <li>Response quality tracking</li>
+                                    <li>Model comparison analytics</li>
+                                    <li>Cost optimization insights</li>
+                                    <li>Performance benchmarking</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Personal Growth Tracking</strong>
+                                <ul>
+                                    <li>Writing skill progression</li>
+                                    <li>Creative milestone achievements</li>
+                                    <li>Learning progress in different topics</li>
+                                    <li>Social interaction improvements</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Integration &amp; Automation</h3>
+                        <ul>
+                            <li>
+                                <strong>External Service Integration</strong>
+                                <ul>
+                                    <li>Calendar and scheduling connectivity</li>
+                                    <li>Note-taking app synchronization</li>
+                                    <li>Social media cross-posting</li>
+                                    <li>Email integration for conversation summaries</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Workflow Automation</strong>
+                                <ul>
+                                    <li>Custom STscript marketplace</li>
+                                    <li>Visual workflow builder</li>
+                                    <li>Trigger-based automation</li>
+                                    <li>Integration with productivity tools</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>API Ecosystem</strong>
+                                <ul>
+                                    <li>RESTful API for third-party integrations</li>
+                                    <li>Webhook support for external events</li>
+                                    <li>Plugin architecture for community extensions</li>
+                                    <li>GraphQL interface for advanced queries</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Advanced Search &amp; Organization</h3>
+                        <ul>
+                            <li>
+                                <strong>Semantic Search Across All Conversations</strong>
+                                <ul>
+                                    <li>Natural language query for finding specific conversations</li>
+                                    <li>Cross-character search capabilities</li>
+                                    <li>Context-aware result ranking</li>
+                                    <li>Advanced filtering and sorting options</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Smart Organization Systems</strong>
+                                <ul>
+                                    <li>AI-powered conversation categorization</li>
+                                    <li>Automatic tagging based on content</li>
+                                    <li>Relationship mapping between characters and topics</li>
+                                    <li>Timeline view of conversation history</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Knowledge Graph Integration</strong>
+                                <ul>
+                                    <li>Visual representation of character relationships</li>
+                                    <li>Topic connection mapping</li>
+                                    <li>Interactive exploration of conversation networks</li>
+                                    <li>Export to graph analysis tools</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Privacy &amp; Security Enhancements</h3>
+                        <ul>
+                            <li>
+                                <strong>Advanced Encryption</strong>
+                                <ul>
+                                    <li>End-to-end encryption for sensitive conversations</li>
+                                    <li>Local-only processing options</li>
+                                    <li>Selective cloud sync with encryption</li>
+                                    <li>Zero-knowledge architecture options</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Privacy Controls</strong>
+                                <ul>
+                                    <li>Granular data sharing permissions</li>
+                                    <li>Automatic PII detection and masking</li>
+                                    <li>Conversation anonymization tools</li>
+                                    <li>Data retention policy customization</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Mobile &amp; Cross-Platform</h3>
+                        <ul>
+                            <li>
+                                <strong>Progressive Web App Enhancement</strong>
+                                <ul>
+                                    <li>Offline conversation capabilities</li>
+                                    <li>Push notification system</li>
+                                    <li>Mobile-optimized gesture controls</li>
+                                    <li>Responsive design improvements</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Cross-Device Synchronization</strong>
+                                <ul>
+                                    <li>Real-time sync across multiple devices</li>
+                                    <li>Device-specific customization preservation</li>
+                                    <li>Bandwidth optimization for mobile</li>
+                                    <li>Conflict resolution for simultaneous edits</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="supertavern-settings-group">
+                        <h3>Community &amp; Social Features</h3>
+                        <ul>
+                            <li>
+                                <strong>Character Sharing Marketplace</strong>
+                                <ul>
+                                    <li>Community-driven character library</li>
+                                    <li>Rating and review system for characters</li>
+                                    <li>Version control for shared characters</li>
+                                    <li>Monetization options for character creators</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Collaborative World Building</strong>
+                                <ul>
+                                    <li>Shared universe creation tools</li>
+                                    <li>Community-driven lore development</li>
+                                    <li>Voting systems for canonical events</li>
+                                    <li>Collaborative timeline management</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <strong>Social Discovery</strong>
+                                <ul>
+                                    <li>Find users with similar interests</li>
+                                    <li>Public conversation showcases</li>
+                                    <li>Community challenges and events</li>
+                                    <li>Mentorship matching system</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="user-settings-button" class="drawer">
+            <div class="drawer-toggle">
+                <div class="drawer-icon fa-solid fa-user-cog fa-fw closedIcon" title="User Settings" data-i18n="[title]User Settings"></div>
+            </div>
+            <div id="user-settings-block" class="drawer-content closedDrawer">
+                <div class="flex-container flexFlowColumn">
+                    <div name="userSettingsRowOne" class="flex-container flexFlowRow alignitemscenter spaceBetween">
+                        <div class="flex-container">
+                            <div class="flex-container flexnowrap alignItemsBaseline">
+                                <h3 class="margin0">
+                                    <span data-i18n="User Settings">User Settings</span>
+
+                                    <a href="https://docs.sillytavern.app/usage/user-settings/" class="notes-link" target="_blank">
+                                        <span class="fa-solid fa-circle-question note-link-span"></span>
+                                    </a>
+                                </h3>
+                            </div>
+                        </div>
+                        <div id="UI-language-block" class="flex-container alignItemsBaseline">
+                            <span data-i18n="UI Language">Language:</span>
+                            <select id="ui_language_select" class="flex1 margin0 text_pole">
+                                <option value="" data-i18n="Default">Default</option>
+                                <option value="en">English</option>
+                            </select>
+                        </div>
+                        <small id="version_display"></small>
+                    </div>
+                    <div name="UserSettingsRowTwo" class="flex-container flexFlowRow">
+                        <div id="account_controls" class="flex-container">
+                            <div id="account_button" class="margin0 menu_button_icon menu_button">
+                                <i class="fa-fw fa-solid fa-user-shield"></i>
+                                <span data-i18n="Account">Account</span>
+                            </div>
+                            <div id="admin_button" class="margin0 menu_button_icon menu_button">
+                                <i class="fa-fw fa-solid fa-user-tie"></i>
+                                <span data-i18n="Admin Panel">Admin Panel</span>
+                            </div>
+                            <div id="logout_button" class="margin0 menu_button_icon menu_button">
+                                <i class="fa-fw fa-solid fa-right-from-bracket"></i>
+                                <span data-i18n="Logout">Logout</span>
+                            </div>
+                        </div>
+                        <textarea id="settingsSearch" class="textarea_compact flex1" rows="1" placeholder="Search Settings" data-i18n="[placeholder]Search Settings"></textarea>
+                    </div>
+                </div>
+                <div id="user-settings-block-content" class="flex-container spaceEvenly">
                     <div name="UserSettingsSecondColumn" id="UI-Customization" class="flex-container flexFlowColumn wide100p flexNoGap flex1">
                         <div name="CharacterHandlingToggles">
                             <h4 data-i18n="Character Handling">
@@ -7775,12 +8171,6 @@
 
             window.addEventListener('resize', documentHeight);
             documentHeight();
-
-            const supertavernTarget = document.getElementById('supertavern-settings-panel');
-            const uiThemeBlock = document.getElementById('UI-Theme-Block');
-            if (supertavernTarget && uiThemeBlock) {
-                supertavernTarget.appendChild(uiThemeBlock);
-            }
 
             const deckSelectors = ['#command-deck', '.command-deck', '[data-command-deck]', '[data-supertavern-command-deck]'];
             for (const selector of deckSelectors) {

--- a/public/index.html
+++ b/public/index.html
@@ -4605,6 +4605,14 @@
                 </div>
             </div>
         </div>
+        <div id="supertavern-settings-button" class="drawer">
+            <div class="drawer-toggle">
+                <div class="drawer-icon fa-solid fa-wand-magic-sparkles fa-fw closedIcon" title="SuperTavern Settings"></div>
+            </div>
+            <div id="supertavern-settings" class="drawer-content closedDrawer">
+                <div id="supertavern-settings-panel" class="flex-container flexFlowColumn wide100p flex1"></div>
+            </div>
+        </div>
         <div id="user-settings-button" class="drawer">
             <div class="drawer-toggle">
                 <div class="drawer-icon fa-solid fa-user-cog fa-fw closedIcon" title="User Settings" data-i18n="[title]User Settings"></div>
@@ -7759,14 +7767,44 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="script.js"></script>
     <script>
-        window.addEventListener('load', (event) => {
+        const initializeSuperTavernLayout = () => {
             const documentHeight = () => {
                 const doc = document.documentElement;
                 doc.style.setProperty('--doc-height', `${window.innerHeight}px`);
-            }
+            };
+
             window.addEventListener('resize', documentHeight);
             documentHeight();
-        });
+
+            const supertavernTarget = document.getElementById('supertavern-settings-panel');
+            const uiThemeBlock = document.getElementById('UI-Theme-Block');
+            if (supertavernTarget && uiThemeBlock) {
+                supertavernTarget.appendChild(uiThemeBlock);
+            }
+
+            const deckSelectors = ['#command-deck', '.command-deck', '[data-command-deck]', '[data-supertavern-command-deck]'];
+            for (const selector of deckSelectors) {
+                document.querySelectorAll(selector).forEach((el) => el.remove());
+            }
+
+            document.querySelectorAll('#top-bar *').forEach((el) => {
+                const text = el.textContent?.trim().toUpperCase();
+                if (text && text.includes('COMMAND DECK')) {
+                    const deckRoot = el.closest('[data-command-deck], [data-supertavern-command-deck], .command-deck');
+                    if (deckRoot) {
+                        deckRoot.remove();
+                    } else {
+                        el.remove();
+                    }
+                }
+            });
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initializeSuperTavernLayout, { once: true });
+        } else {
+            initializeSuperTavernLayout();
+        }
     </script>
 </body>
 

--- a/public/script.js
+++ b/public/script.js
@@ -258,6 +258,12 @@ import { applyBrowserFixes } from './scripts/browser-fixes.js';
 import { initServerHistory } from './scripts/server-history.js';
 import { initSettingsSearch } from './scripts/setting-search.js';
 import { initBulkEdit } from './scripts/bulk-edit.js';
+import {
+    configureSuperTavern,
+    initializeSuperTavernUI,
+    loadSuperTavernState,
+    getSuperTavernState,
+} from './scripts/supertavern-settings.js';
 import { getContext } from './scripts/st-context.js';
 import { extractReasoningFromData, initReasoning, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
 import { accountStorage } from './scripts/util/AccountStorage.js';
@@ -576,6 +582,35 @@ export let active_character = '';
 /** The tag of the active group. (Coincidentally also the id) */
 export let active_group = '';
 
+function getLocalSuperTavernIdentity() {
+    const avatarUrl = user_avatar ? getThumbnailUrl('persona', user_avatar) : '';
+    return {
+        name: name1,
+        avatar: avatarUrl,
+        handle: currentUser?.handle ?? '',
+    };
+}
+
+async function insertSuperTavernRemoteMessage(message, meta = {}) {
+    chat.push(message);
+    addOneMessage(message, { forceId: chat.length - 1 });
+    await eventSource.emit(event_types.MESSAGE_RECEIVED, chat.length - 1, meta.eventTag ?? 'supertavern_remote');
+    await saveChatConditional();
+}
+
+configureSuperTavern({
+    eventSource,
+    event_types,
+    getChat: () => chat,
+    insertRemoteMessage: insertSuperTavernRemoteMessage,
+    reloadCurrentChat,
+    getCurrentChatId,
+    getActiveGroup: () => active_group,
+    getActiveCharacter: () => active_character,
+    getLocalUserIdentity: getLocalSuperTavernIdentity,
+    saveSettingsDebounced,
+});
+
 export const entitiesFilter = new FilterHelper(printCharactersDebounced);
 
 export function getRequestHeaders({ omitContentType = false } = {}) {
@@ -683,6 +718,7 @@ async function firstLoadInit() {
     initServerHistory();
     initSettingsSearch();
     initBulkEdit();
+    initializeSuperTavernUI();
     initReasoning();
     initWelcomeScreen();
     await initScrapers();
@@ -6874,6 +6910,8 @@ export async function getSettings() {
         // Apply theme toggles from power user settings
         applyPowerUserSettings();
 
+        await loadSuperTavernState(settings?.supertavern ?? {});
+
         // Load character tags
         loadTagsSettings(settings);
 
@@ -6975,6 +7013,7 @@ export async function saveSettings(loopCounter = 0) {
         horde_settings: horde_settings,
         power_user: power_user,
         extension_settings: extension_settings,
+        supertavern: getSuperTavernState(),
         tags: tags,
         tag_map: tag_map,
         nai_settings: nai_settings,

--- a/public/scripts/supertavern-settings.js
+++ b/public/scripts/supertavern-settings.js
@@ -1,0 +1,934 @@
+import { debounce, download } from './utils.js';
+
+const DEFAULT_SETTINGS = {
+    multiUser: {
+        enabled: false,
+        crossTalk: true,
+        privateSideChats: true,
+        conflictResolution: true,
+        role: 'participant',
+        clientId: '',
+    },
+    sharedMemory: {
+        enabled: false,
+        projectScoped: true,
+        privacyControls: true,
+        maxEntries: 100,
+        entries: {},
+    },
+    gamification: {
+        enabled: false,
+        xp: 0,
+        level: 1,
+        achievements: [],
+        counters: {
+            message_sent: 0,
+            message_received: 0,
+            remote_message: 0,
+        },
+        lastActivity: 0,
+    },
+    accessibility: {
+        highContrast: false,
+        dyslexiaFriendly: false,
+        reducedMotion: false,
+        focusManagement: true,
+    },
+    team: {
+        analyticsEnabled: false,
+        memberStats: {},
+    },
+    customization: {
+        dynamicThemes: false,
+    },
+};
+
+const CROSS_TALK_REGEX = /^\/([^\s]+)\s+([\s\S]+)$/;
+const BROADCAST_CHANNEL = 'supertavern-multiuser';
+const MAX_SHARED_SUMMARY_LENGTH = 280;
+
+let state = deepClone(DEFAULT_SETTINGS);
+let dependencies = {
+    eventSource: null,
+    event_types: null,
+    getChat: null,
+    insertRemoteMessage: null,
+    reloadCurrentChat: null,
+    getCurrentChatId: null,
+    getActiveGroup: null,
+    getActiveCharacter: null,
+    getLocalUserIdentity: null,
+    saveSettingsDebounced: null,
+};
+
+let broadcastChannel = null;
+let listenersRegistered = false;
+let lastStatus = 'Offline';
+const processedMessages = new Set();
+const remoteMessageVersions = new Map();
+
+const schedulePersist = debounce(() => dependencies.saveSettingsDebounced?.(), 800);
+
+export function configureSuperTavern(newDependencies) {
+    dependencies = { ...dependencies, ...newDependencies };
+    registerCoreListeners();
+}
+
+export function initializeSuperTavernUI() {
+    const panel = getPanel();
+    if (!panel || panel.dataset.supertavernInitialized === 'true') {
+        return;
+    }
+
+    panel.dataset.supertavernInitialized = 'true';
+
+    panel.querySelectorAll('[data-supertavern-setting]').forEach((element) => {
+        const path = element.getAttribute('data-supertavern-setting');
+        if (!path) {
+            return;
+        }
+
+        if (element instanceof HTMLInputElement && element.type === 'checkbox') {
+            element.addEventListener('change', () => {
+                const changed = setStateValue(path, element.checked);
+                if (!changed) {
+                    return;
+                }
+
+                applyState();
+                render();
+                schedulePersist();
+            });
+        } else if (element instanceof HTMLSelectElement) {
+            element.addEventListener('change', () => {
+                const changed = setStateValue(path, element.value);
+                if (!changed) {
+                    return;
+                }
+
+                applyState();
+                render();
+                schedulePersist();
+            });
+        }
+    });
+
+    panel.querySelector('#supertavern-shared-memory-export')?.addEventListener('click', exportSharedMemorySnapshot);
+    panel.querySelector('#supertavern-shared-memory-clear')?.addEventListener('click', clearSharedMemory);
+
+    render();
+}
+
+export async function loadSuperTavernState(savedState = {}) {
+    state = mergeDeep(deepClone(DEFAULT_SETTINGS), savedState ?? {});
+    ensureClientId();
+    applyState();
+    render();
+}
+
+export function getSuperTavernState() {
+    return state;
+}
+
+function registerCoreListeners() {
+    if (listenersRegistered) {
+        return;
+    }
+
+    if (!dependencies.eventSource || !dependencies.event_types) {
+        return;
+    }
+
+    dependencies.eventSource.on(dependencies.event_types.MESSAGE_SENT, handleMessageSent);
+    dependencies.eventSource.on(dependencies.event_types.MESSAGE_RECEIVED, handleMessageReceived);
+    listenersRegistered = true;
+}
+
+function handleMessageSent(messageId) {
+    const message = getMessageById(messageId);
+    if (!message) {
+        return;
+    }
+
+    if (state.multiUser.enabled) {
+        ensureClientId();
+        const channel = ensureMultiUserChannel();
+        if (channel) {
+            broadcastLocalMessage(message);
+        }
+    }
+
+    let changed = false;
+
+    if (state.sharedMemory.enabled) {
+        changed = updateSharedMemory(message, { direction: 'sent' }) || changed;
+    }
+
+    if (state.gamification.enabled && !message.extra?.supertavernRemote) {
+        addExperience('message_sent');
+        changed = true;
+    }
+
+    if (state.team.analyticsEnabled) {
+        changed = updateTeamAnalytics(message) || changed;
+    }
+
+    if (state.customization.dynamicThemes) {
+        updateDynamicTheme();
+    }
+
+    if (changed) {
+        render();
+        schedulePersist();
+    }
+}
+
+function handleMessageReceived(messageId, type) {
+    const message = getMessageById(messageId);
+    if (!message) {
+        return;
+    }
+
+    let changed = false;
+
+    if (state.sharedMemory.enabled) {
+        changed = updateSharedMemory(message, { direction: 'received', type }) || changed;
+    }
+
+    if (state.gamification.enabled) {
+        if (message.extra?.supertavernRemote) {
+            addExperience('remote_message');
+        } else if (!message.is_user) {
+            addExperience('message_received');
+        }
+        changed = true;
+    }
+
+    if (state.team.analyticsEnabled) {
+        changed = updateTeamAnalytics(message) || changed;
+    }
+
+    if (state.customization.dynamicThemes) {
+        updateDynamicTheme();
+    }
+
+    if (changed) {
+        render();
+        schedulePersist();
+    }
+}
+
+function getMessageById(messageId) {
+    const chat = dependencies.getChat?.();
+    if (!Array.isArray(chat)) {
+        return null;
+    }
+
+    return chat[messageId] ?? null;
+}
+
+function ensureMultiUserChannel() {
+    if (!state.multiUser.enabled) {
+        return null;
+    }
+
+    if (broadcastChannel) {
+        return broadcastChannel;
+    }
+
+    if (typeof window.BroadcastChannel !== 'function') {
+        setMultiUserStatus('Unsupported');
+        return null;
+    }
+
+    broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL);
+    broadcastChannel.onmessage = (event) => {
+        onBroadcastMessage(event.data);
+    };
+    setMultiUserStatus('Connected');
+    return broadcastChannel;
+}
+
+function teardownMultiUserChannel() {
+    if (!broadcastChannel) {
+        return;
+    }
+
+    broadcastChannel.close();
+    broadcastChannel = null;
+    setMultiUserStatus('Offline');
+}
+
+function broadcastLocalMessage(message) {
+    if (!message.is_user || message.extra?.supertavernRemote) {
+        return;
+    }
+
+    const channel = ensureMultiUserChannel();
+    if (!channel) {
+        return;
+    }
+
+    const identity = dependencies.getLocalUserIdentity?.() || {};
+    const prepared = prepareBroadcastPayload(message, identity);
+    if (!prepared) {
+        return;
+    }
+
+    processedMessages.add(prepared.id);
+    channel.postMessage(prepared);
+}
+
+function prepareBroadcastPayload(message, identity) {
+    const clone = {
+        ...message,
+        extra: { ...message.extra },
+    };
+
+    const broadcastId = clone.extra?.supertavernMessageId || createClientId();
+    clone.extra.supertavernMessageId = broadcastId;
+
+    const match = state.multiUser.crossTalk ? message.mes?.match(CROSS_TALK_REGEX) : null;
+    let target = null;
+    let sanitizedText = message.mes;
+    if (match) {
+        target = match[1];
+        sanitizedText = match[2];
+        clone.extra.supertavernPrivateRecipients = target;
+    }
+
+    const payload = {
+        id: broadcastId,
+        clientId: state.multiUser.clientId,
+        timestamp: Date.now(),
+        room: getRoomKey(),
+        message: {
+            name: clone.name,
+            mes: sanitizedText,
+            send_date: clone.send_date,
+            extra: {
+                supertavernRemote: true,
+                supertavernOriginRole: state.multiUser.role,
+                supertavernOriginHandle: identity.handle || identity.name || '',
+            },
+        },
+        rawText: message.mes,
+        role: state.multiUser.role,
+        handle: identity.handle || identity.name || '',
+        avatar: identity.avatar || '',
+        target,
+        version: 1,
+    };
+
+    return payload;
+}
+
+async function onBroadcastMessage(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return;
+    }
+
+    if (!state.multiUser.enabled) {
+        return;
+    }
+
+    if (payload.clientId === state.multiUser.clientId) {
+        return;
+    }
+
+    if (payload.room && payload.room !== getRoomKey()) {
+        return;
+    }
+
+    if (processedMessages.has(payload.id)) {
+        if (state.multiUser.conflictResolution) {
+            updateExistingRemoteMessage(payload);
+        }
+        return;
+    }
+
+    const message = transformPayloadToMessage(payload);
+    if (!message) {
+        return;
+    }
+
+    processedMessages.add(payload.id);
+    remoteMessageVersions.set(payload.id, payload.timestamp ?? Date.now());
+
+    await dependencies.insertRemoteMessage?.(message, { broadcastId: payload.id, eventTag: 'supertavern_remote' });
+    render();
+    schedulePersist();
+}
+
+function transformPayloadToMessage(payload) {
+    const identity = dependencies.getLocalUserIdentity?.() || {};
+    const localName = (identity.name || '').toLowerCase();
+    const isModerator = state.multiUser.role === 'moderator';
+    const target = (payload.target || '').toLowerCase();
+    const isPrivate = Boolean(target);
+    const isRecipient = target && localName === target.toLowerCase();
+
+    if (isPrivate && state.multiUser.privateSideChats && !isRecipient && !isModerator) {
+        return null;
+    }
+
+    const messageText = isPrivate && payload.message?.mes ? payload.message.mes : payload.rawText ?? payload.message?.mes ?? '';
+
+    const message = {
+        name: payload.message?.name || payload.handle || 'Participant',
+        is_user: true,
+        is_system: false,
+        send_date: payload.message?.send_date || new Date().toISOString(),
+        mes: messageText,
+        extra: {
+            ...(payload.message?.extra || {}),
+            supertavernRemote: true,
+            supertavernMessageId: payload.id,
+            supertavernOriginRole: payload.role || 'participant',
+            supertavernOriginHandle: payload.handle || payload.message?.name || '',
+        },
+    };
+
+    if (payload.avatar) {
+        message.force_avatar = payload.avatar;
+    }
+
+    if (isPrivate) {
+        message.extra.supertavernPrivateRecipients = payload.target;
+        if (!isRecipient && isModerator) {
+            message.mes = `(Whisper to ${payload.target}) ${payload.message?.mes ?? ''}`;
+        }
+    }
+
+    return message;
+}
+
+function updateExistingRemoteMessage(payload) {
+    const chat = dependencies.getChat?.();
+    if (!Array.isArray(chat)) {
+        return;
+    }
+
+    const index = chat.findIndex((mes) => mes?.extra?.supertavernMessageId === payload.id);
+    if (index === -1) {
+        return;
+    }
+
+    const currentTimestamp = remoteMessageVersions.get(payload.id) ?? 0;
+    if ((payload.timestamp ?? 0) < currentTimestamp) {
+        return;
+    }
+
+    remoteMessageVersions.set(payload.id, payload.timestamp ?? Date.now());
+    chat[index].mes = payload.rawText ?? payload.message?.mes ?? chat[index].mes;
+    chat[index].extra = {
+        ...chat[index].extra,
+        supertavernRemote: true,
+        supertavernMessageId: payload.id,
+        supertavernRevision: (chat[index].extra?.supertavernRevision ?? 0) + 1,
+    };
+    dependencies.reloadCurrentChat?.();
+}
+
+function updateSharedMemory(message, { direction, type }) {
+    if (!state.sharedMemory.enabled) {
+        return false;
+    }
+
+    if (state.sharedMemory.privacyControls && message.extra?.supertavernPrivateRecipients) {
+        return false;
+    }
+
+    const projectKey = getMemoryKey();
+    const entries = getMemoryEntries(projectKey);
+    const highlight = extractHighlight(message);
+
+    if (!highlight) {
+        return false;
+    }
+
+    const entry = {
+        id: message.extra?.supertavernMessageId || createClientId(),
+        author: message.name,
+        role: message.extra?.supertavernOriginRole || (message.is_user ? 'participant' : 'assistant'),
+        text: highlight,
+        timestamp: Date.now(),
+        direction,
+        type,
+    };
+
+    entries.push(entry);
+
+    while (entries.length > (state.sharedMemory.maxEntries || 100)) {
+        entries.shift();
+    }
+
+    if (state.gamification.enabled) {
+        addExperience('shared_memory');
+    }
+
+    return true;
+}
+
+function extractHighlight(message) {
+    const raw = String(message.mes || '').trim();
+    if (!raw) {
+        return '';
+    }
+
+    let text = raw.replace(/\s+/g, ' ');
+    if (text.length > MAX_SHARED_SUMMARY_LENGTH) {
+        text = `${text.slice(0, MAX_SHARED_SUMMARY_LENGTH - 1)}…`;
+    }
+
+    return text;
+}
+
+function getMemoryEntries(projectKey) {
+    if (!state.sharedMemory.entries[projectKey]) {
+        state.sharedMemory.entries[projectKey] = [];
+    }
+
+    return state.sharedMemory.entries[projectKey];
+}
+
+function updateTeamAnalytics(message) {
+    const stats = state.team.memberStats;
+    const key = (message.extra?.supertavernOriginHandle || message.name || 'participant').toLowerCase();
+    const displayName = message.extra?.supertavernOriginHandle || message.name || 'Participant';
+    const role = message.extra?.supertavernOriginRole || (message.is_user ? 'participant' : 'assistant');
+
+    if (!stats[key]) {
+        stats[key] = {
+            name: displayName,
+            role,
+            messages: 0,
+        };
+    }
+
+    stats[key].messages += 1;
+    stats[key].role = role;
+    return true;
+}
+
+function addExperience(kind) {
+    const xpMap = {
+        message_sent: 5,
+        message_received: 2,
+        remote_message: 6,
+        shared_memory: 3,
+        feature_toggle: 8,
+    };
+
+    const xpGain = xpMap[kind] ?? 1;
+    state.gamification.xp += xpGain;
+    state.gamification.counters[kind] = (state.gamification.counters[kind] ?? 0) + 1;
+    state.gamification.lastActivity = Date.now();
+
+    const newLevel = Math.max(1, Math.floor(state.gamification.xp / 100) + 1);
+    if (newLevel !== state.gamification.level) {
+        state.gamification.level = newLevel;
+        grantAchievement('level-' + newLevel, `Reached level ${newLevel}`);
+    }
+
+    if (kind === 'remote_message') {
+        grantAchievement('collaboration', 'Welcomed a collaborator');
+    }
+
+    if (state.gamification.counters.message_sent === 1) {
+        grantAchievement('first-message', 'Sent your first message');
+    }
+
+    if (state.gamification.counters.message_sent === 100) {
+        grantAchievement('hundred-messages', 'Sent 100 messages');
+    }
+
+    updateDynamicTheme();
+}
+
+function grantAchievement(id, label) {
+    if (state.gamification.achievements.includes(id)) {
+        return;
+    }
+
+    state.gamification.achievements.push(id);
+    window.toastr?.success(label, 'Achievement unlocked');
+}
+
+function render() {
+    syncUIFromState();
+    updateConditionalBlocks();
+    renderMultiUserStatus();
+    renderSharedMemory();
+    renderTeamAnalytics();
+    renderGamification();
+    applyAccessibilityClasses();
+    updateDynamicTheme();
+}
+
+function syncUIFromState() {
+    const panel = getPanel();
+    if (!panel) {
+        return;
+    }
+
+    panel.querySelectorAll('[data-supertavern-setting]').forEach((element) => {
+        const path = element.getAttribute('data-supertavern-setting');
+        if (!path) {
+            return;
+        }
+
+        const value = getStateValue(path);
+
+        if (element instanceof HTMLInputElement && element.type === 'checkbox') {
+            if (element.checked !== Boolean(value)) {
+                element.checked = Boolean(value);
+            }
+        } else if (element instanceof HTMLSelectElement) {
+            if (element.value !== String(value)) {
+                element.value = String(value);
+            }
+        }
+    });
+}
+
+function updateConditionalBlocks() {
+    const panel = getPanel();
+    if (!panel) {
+        return;
+    }
+
+    panel.querySelectorAll('[data-supertavern-requires]').forEach((element) => {
+        const requirement = element.getAttribute('data-supertavern-requires');
+        const isActive = Boolean(getStateValue(requirement));
+        element.toggleAttribute('hidden', !isActive);
+    });
+}
+
+function renderMultiUserStatus() {
+    const statusElement = document.getElementById('supertavern-multiuser-status');
+    if (!statusElement) {
+        return;
+    }
+
+    statusElement.textContent = lastStatus;
+}
+
+function renderSharedMemory() {
+    const list = document.getElementById('supertavern-shared-memory-list');
+    if (!list) {
+        return;
+    }
+
+    list.textContent = '';
+
+    const projectKey = getMemoryKey();
+    const entries = getMemoryEntries(projectKey);
+
+    if (!entries.length) {
+        const empty = document.createElement('li');
+        empty.textContent = 'Shared memory will collect highlights from the active project.';
+        list.append(empty);
+        return;
+    }
+
+    for (const entry of entries) {
+        const item = document.createElement('li');
+        const time = document.createElement('time');
+        time.dateTime = new Date(entry.timestamp).toISOString();
+        time.textContent = new Date(entry.timestamp).toLocaleString();
+
+        const text = document.createElement('span');
+        text.textContent = `${entry.author}: ${entry.text}`;
+
+        item.append(time, text);
+        list.append(item);
+    }
+}
+
+function renderTeamAnalytics() {
+    const list = document.getElementById('supertavern-team-analytics');
+    if (!list) {
+        return;
+    }
+
+    list.textContent = '';
+
+    if (!state.team.analyticsEnabled) {
+        return;
+    }
+
+    const values = Object.values(state.team.memberStats || {});
+    if (!values.length) {
+        const empty = document.createElement('li');
+        empty.textContent = 'No activity recorded yet.';
+        list.append(empty);
+        return;
+    }
+
+    values.sort((a, b) => b.messages - a.messages);
+
+    for (const member of values) {
+        const item = document.createElement('li');
+        const name = document.createElement('span');
+        name.textContent = `${member.name} (${member.role})`;
+        const count = document.createElement('span');
+        count.textContent = `${member.messages.toLocaleString()} messages`;
+        item.append(name, count);
+        list.append(item);
+    }
+}
+
+function renderGamification() {
+    const levelElement = document.getElementById('supertavern-xp-level');
+    const progressElement = document.getElementById('supertavern-xp-progress');
+    const xpValueElement = document.getElementById('supertavern-xp-value');
+    const achievementsElement = document.getElementById('supertavern-achievements');
+
+    if (!levelElement || !progressElement || !xpValueElement || !achievementsElement) {
+        return;
+    }
+
+    if (!state.gamification.enabled) {
+        achievementsElement.textContent = '';
+        return;
+    }
+
+    const xp = state.gamification.xp;
+    const currentLevel = Math.max(1, Math.floor(xp / 100) + 1);
+    const xpIntoLevel = xp % 100;
+
+    levelElement.textContent = `Level ${currentLevel}`;
+    progressElement.value = xpIntoLevel;
+    progressElement.max = 100;
+    xpValueElement.textContent = `${xp.toLocaleString()} XP`;
+
+    achievementsElement.textContent = '';
+    if (!state.gamification.achievements.length) {
+        const empty = document.createElement('li');
+        empty.textContent = 'Complete activities to unlock achievements.';
+        achievementsElement.append(empty);
+        return;
+    }
+
+    for (const achievement of state.gamification.achievements) {
+        const item = document.createElement('li');
+        item.textContent = `✔ ${formatAchievementLabel(achievement)}`;
+        achievementsElement.append(item);
+    }
+}
+
+function formatAchievementLabel(id) {
+    if (id.startsWith('level-')) {
+        return `Reached ${id.replace('level-', 'level ')}`;
+    }
+
+    const labels = {
+        'first-message': 'Sent the first message',
+        'hundred-messages': 'Sent 100 messages',
+        collaboration: 'Welcomed a collaborator',
+    };
+
+    return labels[id] || id;
+}
+
+function applyAccessibilityClasses() {
+    const root = document.documentElement;
+    const body = document.body;
+    if (!root || !body) {
+        return;
+    }
+
+    root.classList.toggle('supertavern-high-contrast', Boolean(state.accessibility.highContrast));
+    root.classList.toggle('supertavern-dyslexia', Boolean(state.accessibility.dyslexiaFriendly));
+    root.classList.toggle('supertavern-reduced-motion', Boolean(state.accessibility.reducedMotion));
+    body.classList.toggle('supertavern-focus-tools', Boolean(state.accessibility.focusManagement));
+}
+
+function updateDynamicTheme() {
+    const body = document.body;
+    if (!body) {
+        return;
+    }
+
+    if (!state.customization.dynamicThemes) {
+        body.classList.remove('supertavern-dynamic-theme');
+        document.documentElement.style.removeProperty('--supertavern-theme-alpha');
+        return;
+    }
+
+    body.classList.add('supertavern-dynamic-theme');
+    const xp = state.gamification.enabled ? state.gamification.xp : 0;
+    const intensity = Math.min(0.35, 0.1 + (xp % 100) / 500);
+    document.documentElement.style.setProperty('--supertavern-theme-alpha', intensity.toFixed(3));
+}
+
+function applyState() {
+    ensureClientId();
+
+    if (!state.multiUser.enabled) {
+        teardownMultiUserChannel();
+    }
+
+    applyAccessibilityClasses();
+    updateDynamicTheme();
+}
+
+function ensureClientId() {
+    if (!state.multiUser.clientId) {
+        state.multiUser.clientId = createClientId();
+    }
+}
+
+function getStateValue(path) {
+    return path.split('.').reduce((accumulator, key) => {
+        if (accumulator && typeof accumulator === 'object') {
+            return accumulator[key];
+        }
+        return undefined;
+    }, state);
+}
+
+function setStateValue(path, value) {
+    const keys = path.split('.');
+    let target = state;
+    for (let i = 0; i < keys.length - 1; i++) {
+        const key = keys[i];
+        if (typeof target[key] !== 'object' || target[key] === null) {
+            target[key] = {};
+        }
+        target = target[key];
+    }
+
+    const lastKey = keys[keys.length - 1];
+    if (target[lastKey] === value) {
+        return false;
+    }
+
+    target[lastKey] = value;
+
+    if (path.startsWith('multiUser') && path !== 'multiUser.clientId') {
+        if (!state.multiUser.enabled) {
+            teardownMultiUserChannel();
+        } else {
+            ensureMultiUserChannel();
+        }
+    }
+
+    if (path.startsWith('accessibility')) {
+        applyAccessibilityClasses();
+    }
+
+    if (path.startsWith('customization')) {
+        updateDynamicTheme();
+    }
+
+    if (path === 'gamification.enabled') {
+        schedulePersist();
+    }
+
+    if (path === 'team.analyticsEnabled' && !value) {
+        state.team.memberStats = {};
+    }
+
+    if (path === 'sharedMemory.enabled' && !value) {
+        // Keep stored data but stop updating until re-enabled
+        renderSharedMemory();
+    }
+
+    if (path.endsWith('enabled') && state.gamification.enabled) {
+        addExperience('feature_toggle');
+    }
+
+    return true;
+}
+
+function exportSharedMemorySnapshot() {
+    const projectKey = getMemoryKey();
+    const entries = getMemoryEntries(projectKey);
+    const payload = {
+        project: projectKey,
+        generatedAt: new Date().toISOString(),
+        entries,
+    };
+
+    const blob = JSON.stringify(payload, null, 2);
+    download(blob, `supertavern-memory-${projectKey}.json`, 'application/json');
+}
+
+function clearSharedMemory() {
+    if (!window.confirm('Clear the shared memory for this project?')) {
+        return;
+    }
+
+    const key = getMemoryKey();
+    state.sharedMemory.entries[key] = [];
+    renderSharedMemory();
+    schedulePersist();
+}
+
+function getMemoryKey() {
+    if (!state.sharedMemory.projectScoped) {
+        return 'global';
+    }
+
+    return getRoomKey();
+}
+
+function getRoomKey() {
+    const group = dependencies.getActiveGroup?.();
+    if (group) {
+        return `group:${group}`;
+    }
+
+    const chatId = dependencies.getCurrentChatId?.();
+    if (chatId !== undefined && chatId !== null) {
+        return `chat:${chatId}`;
+    }
+
+    const character = dependencies.getActiveCharacter?.();
+    if (character) {
+        return `character:${character}`;
+    }
+
+    return 'global';
+}
+
+function setMultiUserStatus(status) {
+    lastStatus = status;
+    renderMultiUserStatus();
+}
+
+function deepClone(obj) {
+    if (typeof structuredClone === 'function') {
+        return structuredClone(obj);
+    }
+
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function mergeDeep(target, source) {
+    const output = Array.isArray(target) ? [...target] : { ...target };
+    if (source && typeof source === 'object') {
+        Object.keys(source).forEach((key) => {
+            if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+                output[key] = mergeDeep(output[key] || {}, source[key]);
+            } else {
+                output[key] = source[key];
+            }
+        });
+    }
+    return output;
+}
+
+function createClientId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    return `client-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function getPanel() {
+    return document.getElementById('supertavern-settings-panel');
+}

--- a/public/style.css
+++ b/public/style.css
@@ -5212,39 +5212,213 @@ body:has(#character_popup.open) #top-settings-holder:has(.drawer-content.openDra
 .supertavern-settings-panel {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 14px;
 }
 
 .supertavern-settings-group {
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 10px;
-    padding: 14px 18px;
-    backdrop-filter: blur(4px);
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 12px;
+    padding: 16px 20px;
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .supertavern-settings-group h3 {
-    margin: 0 0 8px;
-    font-size: 1.05rem;
+    margin: 0;
+    font-size: 1.08rem;
+    letter-spacing: 0.01em;
 }
 
-.supertavern-settings-group ul {
+.supertavern-description {
     margin: 0;
-    padding-left: 1.2rem;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.supertavern-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.supertavern-toggle input[type="checkbox"] {
+    accent-color: var(--SmartThemeAccentColor, #6ec6ff);
+}
+
+.supertavern-subgroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-left: 8px;
+    border-left: 2px solid rgba(255, 255, 255, 0.08);
+}
+
+.supertavern-subgroup[hidden] {
+    display: none !important;
+}
+
+.supertavern-role-select {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.supertavern-role-select select {
+    background: rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 6px;
+    padding: 4px 8px;
+    color: inherit;
+}
+
+.supertavern-status {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.supertavern-memory-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.supertavern-shared-memory {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.supertavern-shared-memory ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.supertavern-shared-memory li {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.9rem;
+}
+
+.supertavern-shared-memory time {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.supertavern-hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.supertavern-team-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.supertavern-team-list li {
+    display: flex;
+    justify-content: space-between;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 0.9rem;
+}
+
+.supertavern-xp-meter {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.supertavern-xp-meter progress {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.supertavern-xp-meter progress::-webkit-progress-bar {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.supertavern-xp-meter progress::-webkit-progress-value {
+    background: linear-gradient(90deg, #5eb9ff, #ac6cff);
+}
+
+.supertavern-xp-meter progress::-moz-progress-bar {
+    background: linear-gradient(90deg, #5eb9ff, #ac6cff);
+}
+
+.supertavern-xp-value {
+    font-variant-numeric: tabular-nums;
+}
+
+.supertavern-subheading {
+    margin: 4px 0;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.supertavern-achievement-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
     display: grid;
     gap: 6px;
+}
+
+.supertavern-achievement-list li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+}
+
+.supertavern-roadmap {
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.supertavern-roadmap-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 4px;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.supertavern-roadmap-list li {
     list-style: disc;
-}
-
-.supertavern-settings-group ul ul {
-    margin-top: 6px;
-    list-style: circle;
-}
-
-.supertavern-settings-group li > strong {
-    display: block;
-    margin-bottom: 4px;
-    font-size: 0.95rem;
 }
 
 #ui-settings-button .drawer-toggle,
@@ -5276,6 +5450,53 @@ body:has(#character_popup.open) #top-settings-holder:has(.drawer-content.openDra
     cursor: pointer;
     font-size: var(--topBarIconSize);
     padding: 1px 3px;
+}
+
+html.supertavern-high-contrast,
+html.supertavern-high-contrast body {
+    background-color: #050505 !important;
+    color: #f5f5f5 !important;
+}
+
+html.supertavern-high-contrast .mes_block {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border-color: rgba(255, 255, 255, 0.45) !important;
+}
+
+html.supertavern-high-contrast a {
+    color: #63d0ff;
+}
+
+html.supertavern-dyslexia body {
+    font-family: 'OpenDyslexic', 'Comic Neue', 'Verdana', sans-serif;
+    letter-spacing: 0.02em;
+    line-height: 1.6;
+}
+
+html.supertavern-dyslexia #chat .mes_block {
+    font-size: 1.02em;
+}
+
+html.supertavern-reduced-motion,
+html.supertavern-reduced-motion *,
+html.supertavern-reduced-motion *::before,
+html.supertavern-reduced-motion *::after {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+    scroll-behavior: auto !important;
+}
+
+body.supertavern-focus-tools :focus-visible {
+    outline: 2px solid var(--SmartThemeAccentColor, #6ec6ff);
+    outline-offset: 2px;
+}
+
+body.supertavern-dynamic-theme {
+    background-image:
+        radial-gradient(circle at 25% 10%, rgba(94, 185, 255, var(--supertavern-theme-alpha, 0.18)) 0%, transparent 60%),
+        radial-gradient(circle at 80% 90%, rgba(172, 108, 255, var(--supertavern-theme-alpha, 0.18)) 0%, transparent 65%);
+    background-attachment: fixed;
+    background-blend-mode: screen;
 }
 
 .drawer-icon.openIcon {

--- a/public/style.css
+++ b/public/style.css
@@ -5209,6 +5209,68 @@ body:has(#character_popup.open) #top-settings-holder:has(.drawer-content.openDra
     width: 100%;
 }
 
+.supertavern-settings-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.supertavern-settings-group {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 14px 18px;
+    backdrop-filter: blur(4px);
+}
+
+.supertavern-settings-group h3 {
+    margin: 0 0 8px;
+    font-size: 1.05rem;
+}
+
+.supertavern-settings-group ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 6px;
+    list-style: disc;
+}
+
+.supertavern-settings-group ul ul {
+    margin-top: 6px;
+    list-style: circle;
+}
+
+.supertavern-settings-group li > strong {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 0.95rem;
+}
+
+#ui-settings-button .drawer-toggle,
+#supertavern-settings-button .drawer-toggle {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+#ui-settings-button .drawer-icon,
+#supertavern-settings-button .drawer-icon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+#ui-settings-button .drawer-label,
+#supertavern-settings-button .drawer-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
 .drawer-icon {
     display: inline-block;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add a dedicated SuperTavern settings drawer in the top bar for UI controls
- move the existing UI theme panel into that drawer during initialization and strip out any Command Deck overlay elements

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d6c14111e8832b856f5061d1cc941b